### PR TITLE
Update cluster.go

### DIFF
--- a/src/models/cluster.go
+++ b/src/models/cluster.go
@@ -155,6 +155,10 @@ func (c *Cluster) BuildTable(params []interface{}, reply *string) {
 			*reply = ""
 			end.Call("Node.UpdateConstrain", []interface{}{projtableschema.TableName, rulecoef}, &reply)
 			fmt.Println("reply = ", *reply)
+			
+			var ruleback *[]uint8
+			end.Call("Node.ReadConstrain", projtableschema.TableName, &ruleback)
+			fmt.Println("ruleback = ", *ruleback)
 		}
 	}
 }


### PR DESCRIPTION
在BuildTable中添加了ReadConstrain函数的调试代码，目前node.go中的UpdateConstrain函数能传入参数但是还不能将rule赋值给Constrain（不知道是否因为数组不能直接赋值）